### PR TITLE
fix(onprem): Allow rejectUnauthorized via env variable and keep default cities1000

### DIFF
--- a/app.js
+++ b/app.js
@@ -59,7 +59,7 @@ app.listen(port, function () {
   );
   geocoder.init(
     {
-      citiesFileOverride: 'cities500',
+      citiesFileOverride: null,
       load: {
         admin1: true,
         admin2: true,

--- a/index.js
+++ b/index.js
@@ -174,6 +174,27 @@ var geocoder = {
     );
   },
 
+  _getHttpsOptions: function () {
+    var httpsOptions
+    const rejectUnauthorizedEnv = process.env.SHOULD_REJECT_UNAUTHORIZED
+    if (rejectUnauthorizedEnv !== null && rejectUnauthorizedEnv !== undefined) {
+      var rejectUnauthorized = rejectUnauthorizedEnv.toLowerCase()
+      if (rejectUnauthorizedEnv === 'false') {
+        rejectUnauthorized = false
+      } else if (rejectUnauthorizedEnv === 'true') {
+        rejectUnauthorized = true
+      }
+
+      httpsOptions = {
+        rejectUnauthorized,
+      }
+    }
+
+    console.log(`_getHttpsOptions - ${httpsOptions}`)
+
+    return httpsOptions
+  },
+
   _downloadFile: function (
     dataName,
     geonamesZipFilename,
@@ -189,10 +210,18 @@ var geocoder = {
       `Getting GeoNames ${dataName} data from ${geonamesUrl} (this may take a while)`
     );
 
-    request({
+    const requestOptions = {
       url: geonamesUrl,
       encoding: null,
-    })
+    }
+
+    const maybeHttpsOptions = this._getHttpsOptions()
+    console.log(`_downloadFile - ${geonamesUrl} - rejectUnauthorized - ${maybeHttpsOptions.rejectUnauthorized}`)
+    if (maybeHttpsOptions !== null && maybeHttpsOptions !== undefined) {
+      requestOptions['rejectUnauthorized'] = maybeHttpsOptions.rejectUnauthorized
+    }
+
+    request(requestOptions)
       .on('error', (err) => {
         callback(
           `Error downloading GeoNames ${dataName} data` +
@@ -229,11 +258,19 @@ var geocoder = {
       `Getting GeoNames ${dataName} data from ${geonamesUrl} (this may take a while)`
     );
 
-    let foundFiles = 0;
-    request({
+    const requestOptions = {
       url: geonamesUrl,
       encoding: null,
-    })
+    }
+
+    const maybeHttpsOptions = this._getHttpsOptions()
+    console.log(`_downloadAndExtractFileFromZip - ${geonamesUrl} - rejectUnauthorized - ${maybeHttpsOptions.rejectUnauthorized}`)
+    if (maybeHttpsOptions !== null && maybeHttpsOptions !== undefined) {
+      requestOptions['rejectUnauthorized'] = maybeHttpsOptions.rejectUnauthorized
+    }
+
+    let foundFiles = 0;
+    request(requestOptions)
       .on('error', (err) => {
         callback(
           `Error downloading GeoNames ${dataName} data` +


### PR DESCRIPTION
### Tasks
[UI - New 23.11 OnPrem - weld-reverse-geocoder not starting - Issue with self-signed certs](https://app.asana.com/0/1200469496011803/1206025113100643)

Self-signed cert issue workaround

Also adding `citiesFileOverride: null` into the `init` block as we don't need to override the cities file with the 500 version (all cities with populations greater than 500 instead of greater than 1000).