### PR TITLE
fix(security): Bump node version to address nghttp2 vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:21.1.0-alpine3.17
+FROM node:21.2.0-alpine3.18
 RUN apk update && apk upgrade --no-cache
 RUN apk add --no-cache openssl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 RUN apk upgrade busybox --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main

--- a/package-lock.json
+++ b/package-lock.json
@@ -3002,7 +3002,7 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "4.1.3",
+        "tough-cookie": "^4.1.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
       },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "unzip-stream": "^0.3.1"
   },
   "overrides": {
-    "tough-cookie": "4.1.3"
+    "tough-cookie": "^4.1.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
[nghttp2 1.39.2-r0 (3 high)](https://app.asana.com/0/1205888237762535/1205908986285891)
<img width="705" alt="Screenshot 2023-11-30 at 9 04 09 AM" src="https://github.com/Accedian/local-reverse-geocoder/assets/83970048/83b6bc94-a798-401a-b239-355bcac0f0e2">
