### PR TITLE
fix(build): split or docker file into a build and runner as well as using a base hardened image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,59 @@
-FROM node:22-alpine
+FROM node:22-alpine AS build
 
-RUN apk update && \
-  apk add --no-cache \
-  openssl --repository=http://dl-cdn.alpinelinux.org/alpine/latest-stable/main \
-  curl --repository=http://dl-cdn.alpinelinux.org/alpine/latest-stable/main \
-  busybox --repository=http://dl-cdn.alpinelinux.org/alpine/latest-stable/main && \
-  apk upgrade
+RUN apk update && apk add --no-cache curl && apk upgrade
 
-WORKDIR /app
+ARG WORKDIR_BASE=/usr/src/app
+ARG GEONAMES_DUMP_DIR=${WORKDIR_BASE}/geonames_dump
+WORKDIR ${WORKDIR_BASE}
 
-COPY package.json .
-COPY package-lock.json .
-COPY postinstall.js .
-COPY app.js .
-COPY index.js .
+# Create directories
+RUN mkdir -p \
+  ${GEONAMES_DUMP_DIR}/admin1_codes \
+  ${GEONAMES_DUMP_DIR}/admin2_codes \
+  ${GEONAMES_DUMP_DIR}/all_countries \
+  ${GEONAMES_DUMP_DIR}/alternate_names \
+  ${GEONAMES_DUMP_DIR}/cities
+
+# Download and process geonames data
+RUN curl -L -o ${GEONAMES_DUMP_DIR}/admin1_codes/admin1CodesASCII.txt https://download.geonames.org/export/dump/admin1CodesASCII.txt && \
+  curl -L -o ${GEONAMES_DUMP_DIR}/admin2_codes/admin2Codes.txt https://download.geonames.org/export/dump/admin2Codes.txt && \
+  curl -L -o ${GEONAMES_DUMP_DIR}/all_countries/allCountries.zip https://download.geonames.org/export/dump/allCountries.zip && \
+  curl -L -o ${GEONAMES_DUMP_DIR}/alternate_names/alternateNames.zip https://download.geonames.org/export/dump/alternateNames.zip && \
+  curl -L -o ${GEONAMES_DUMP_DIR}/cities/cities1000.zip https://download.geonames.org/export/dump/cities1000.zip && \
+  unzip ${GEONAMES_DUMP_DIR}/all_countries/allCountries.zip -d ${GEONAMES_DUMP_DIR}/all_countries && \
+  unzip ${GEONAMES_DUMP_DIR}/alternate_names/alternateNames.zip -d ${GEONAMES_DUMP_DIR}/alternate_names && \
+  unzip ${GEONAMES_DUMP_DIR}/cities/cities1000.zip -d ${GEONAMES_DUMP_DIR}/cities && \
+  rm ${GEONAMES_DUMP_DIR}/*/*.zip
+
+COPY package.json package-lock.json postinstall.js app.js index.js ./
 RUN npm install
 
-RUN mkdir -p \
-        /app/geonames_dump/admin1_codes \
-        /app/geonames_dump/admin2_codes \
-        /app/geonames_dump/all_countries \
-        /app/geonames_dump/alternate_names \
-        /app/geonames_dump/cities && \
-    cd /app/geonames_dump && \
-    curl -k -L -o admin1_codes/admin1CodesASCII.txt https://download.geonames.org/export/dump/admin1CodesASCII.txt && \
-    curl -k -L -o admin2_codes/admin2Codes.txt https://download.geonames.org/export/dump/admin2Codes.txt && \
-    curl -k -L -o all_countries/allCountries.zip https://download.geonames.org/export/dump/allCountries.zip && \
-    curl -k -L -o alternate_names/alternateNames.zip https://download.geonames.org/export/dump/alternateNames.zip && \
-    curl -k -L -o cities/cities1000.zip https://download.geonames.org/export/dump/cities1000.zip && \
-    cd all_countries && unzip allCountries.zip && rm allCountries.zip && cd .. && \
-    cd cities && unzip cities1000.zip && rm cities1000.zip && cd .. && \
-    cd alternate_names && unzip alternateNames.zip && rm alternateNames.zip
+FROM gcr.io/npav-172917/sto-ccc-cloud9/hardened_alpine:3.21-fips-2025.05.15 AS runner
 
+WORKDIR /usr/src/app
+
+RUN addgroup -S node && \
+  adduser -S node -G node && \
+  chown -R node:node /usr/src/app
+
+COPY --from=build --chown=node:node /usr/src/app/node_modules ./node_modules
+COPY --from=build --chown=node:node /usr/src/app/geonames_dump ./geonames_dump
+COPY --from=build --chown=node:node /usr/src/app/package.json ./package.json
+COPY --from=build --chown=node:node /usr/src/app/app.js ./app.js
+COPY --from=build --chown=node:node /usr/src/app/index.js ./index.js
+
+RUN apk update && \
+  apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/v3.21/main nodejs npm && \
+  apk add --no-cache dumb-init && \
+  apk add --no-cache openssl --repository=http://dl-cdn.alpinelinux.org/alpine/latest-stable/main && \
+  apk upgrade && \
+  echo "Node.js: $(node --version)" && \
+  echo "Npm: $(npm --version)" && \
+  echo "OpenSSL: $(openssl version)" && \
+  rm -rf /var/cache/apk/*
+
+# run as non-root user
+USER node
+EXPOSE 3000
 ENTRYPOINT ["npm"]
 CMD ["start"]
-
-EXPOSE 3000

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ endif
 BUILD_PLATFORMS ?= linux/amd64,linux/arm64/v8
 
 dockerbin: .FORCE
-	npm install
 
 docker: dockerbin
 	echo "building with $(LOCAL_BUILD_PLATFORM)"


### PR DESCRIPTION
### Tasks
[Vulnerabilities in curl 8.7.1-r0](https://app.asana.com/1/5557457880942/project/1207589768566168/task/1211025114938506)
[Vulnerabilities in curl 8.7.1-r0](https://app.asana.com/1/5557457880942/project/1207589768566168/task/1211025114938587)
[Geocoder - Update docker image to be split between build and runner](https://app.asana.com/1/5557457880942/project/1208298116463384/task/1211184461398850)

### Summary
- Split the dockerfile into build and runner steps to reduce unused runtime dependencies.
- Updated the runner to use the base hardened alpine image.
- Removed redundant `npm install` in `Makefile`.

