### PR TITLE
fix(build): forced an full name override in helm to weld-reverse-geocoder

### DIFF
--- a/helm/values.yaml.in
+++ b/helm/values.yaml.in
@@ -1,3 +1,5 @@
+fullnameOverride: weld-reverse-geocoder
+
 replicaCount: 1
 
 image:


### PR DESCRIPTION
### Summary
- Adding a fullnameOverride to the helm chart to prevent the deployer from renaming the service.