### PR TITLE
ci: migrate to pca-bes orb v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  pca-bes: accedian/pca-bes@1
+  pca-bes: accedian/pca-bes@2.1.0
 jobs:
   build_and_release:
     machine: true
@@ -17,15 +17,9 @@ jobs:
             git fetch --tags
             bash .circleci/scripts/determine-version.sh
       - run:
-          name: "Install helm"
-          command: |
-            wget -LO helm.tar.gz https://get.helm.sh/helm-v3.17.2-linux-amd64.tar.gz
-            tar xf helm.tar.gz linux-amd64/helm
-            sudo mv linux-amd64/helm /usr/bin
-      - run:
           name: "Login to Artifact Registry"
           command: |
-            echo ${GCR_DOCKER_RW_PASSWORD} | base64 -d | docker login -u _json_key --password-stdin https://us-docker.pkg.dev
+            echo ${GCR_DOCKER_PASSWORD} | base64 -d | docker login -u ${GCR_DOCKER_USERNAME} --password-stdin https://us-docker.pkg.dev
       - run:
           name: "Build and push Docker image + Helm chart"
           command: |
@@ -66,13 +60,13 @@ workflows:
   build:
     jobs:
       - build_and_release:
-          context: bes-builder-gcp-skybuilder-prd-51843
+          context: bes-builder-gcp-skybuilder-prd-51843-rw
           filters:
             branches:
               only:
                 - main
                 - /^release\/[0-9]+\.[0-9]+\.[0-9]+$/
       - image_signing:
-          context: bes-builder-gcp-skybuilder-prd-51843
+          context: bes-builder-gcp-skybuilder-prd-51843-rw
           requires:
             - build_and_release


### PR DESCRIPTION
## Summary

- Migrate the CircleCI pipeline from `accedian/pca-bes@1` to `accedian/pca-bes@2.1.0`.
- Use the read-only context for build and test jobs, and the read-write context for release and signing jobs.
- Adopt the generic GCR credential names exported by the Vault5 OIDC-backed contexts.
- Remove redundant Helm downloads and password-in-command-argument patterns where present.

## Validation

- `circleci config validate .circleci/config.yml --org-slug github/Accedian`

## Tracking

This change is part of the BES-244343 CI security rollout.